### PR TITLE
[WIP]商品購入完了ページの再編集

### DIFF
--- a/app/controllers/purchase_controller.rb
+++ b/app/controllers/purchase_controller.rb
@@ -29,6 +29,8 @@ class PurchaseController < ApplicationController
     end
 
     def done
+      # @prefecture = Address.find(1)
+      # @show = @prefecture.prefecture_id.prefectures
     end
 
 

--- a/app/controllers/purchase_controller.rb
+++ b/app/controllers/purchase_controller.rb
@@ -29,18 +29,13 @@ class PurchaseController < ApplicationController
     end
 
     def done
-      # @prefecture = Address.find(1)
-      # @show = @prefecture.prefecture_id.prefectures
     end
-
 
     def delete
       @good = Good.find_by(id: params[:id])
       @good.destroy
       redirect_to("/")
     end
-
-    
 
 # 以下テスト用ダミーです。近日けす予定多分大丈夫なはず。9/29 YS
     def show

--- a/app/views/purchase/done.html.haml
+++ b/app/views/purchase/done.html.haml
@@ -34,15 +34,17 @@
         送料込み
 
     -# 配送先情報
+    - shipping = current_user.address  # 現在のユーザーのアドレステーブル読み出しまでを変数化
     .purchase-completed-wrapper__main-container__address
       .purchase-completed-wrapper__main-container__address__title
         配送先
       .purchase-completed-wrapper__main-container__address__post-code
-        = "〒#{@good.user.address.postalcode}"
+        = "〒#{shipping.postalcode}"
       .purchase-completed-wrapper__main-container__address__city
-        = @good.user.address.city
+        = "#{shipping.prefecture.name + shipping.city + shipping.house_number + shipping.building_name}"
       .purchase-completed-wrapper__main-container__address__name
-        = "#{@good.user.address.family_name + @good.user.address.first_name}"
+        = "#{shipping.family_name + shipping.first_name}"
+        
 
 
 

--- a/app/views/shared/_purchase-confirmation.html.haml
+++ b/app/views/shared/_purchase-confirmation.html.haml
@@ -39,16 +39,17 @@
                 %button.btn 購入する
     
     -# ユーザー情報、配送先
+    - shipping = current_user.address  # 現在のユーザーのアドレステーブル読み出しまでを変数化
     %section.confirmation-main__container__buy-info
       .confirmation-main__container__buy-info__container
         %h3 配送先
         %address.confirmation-main__container__buy-info__container__address
           .confirmation-main__container__buy-info__container__address__postal-code 
-            = "〒#{current_user.address.postalcode}"
+            = "〒#{shipping.postalcode}"
           .confirmation-main__container__buy-info__container__address__address-name 
-            = current_user.address.city
+            = "#{shipping.prefecture.name + shipping.city + shipping.house_number + shipping.building_name}"
           .confirmation-main__container__buy-info__container__address__user-name  
-            = "#{current_user.address.family_name + current_user.address.first_name}"
+            = "#{shipping.family_name + shipping.first_name}"
           =link_to  '#', class: 'confirmation-main__container__buy-info__container__user-info-fix' do
             変更する
             %i.fas.fa-chevron-right


### PR DESCRIPTION
#What
商品購入完了ページの再編集を行う
before: 商品購入完了時、「お届け先住所」の情報が出品者の住所になっている
after: 「お届け先住所」部分に「購入者の住所」が適切に表示されるように変更
#Why
お届け先を表示することがマストなため